### PR TITLE
fix(virtualbox): revert guest additions to stable version

### DIFF
--- a/src/Vagrantfile
+++ b/src/Vagrantfile
@@ -16,7 +16,7 @@ Vagrant.configure("2") do |config|
 
     vb.customize ["modifyvm", :id, "--audiocontroller", "hda"]
 
-    vb.customize ["modifyvm", :id, "--clipboard-mode", "bidirectional"]
+    vb.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
     vb.customize ["modifyvm", :id, "--draganddrop", "bidirectional"]
 
     # Make the DNS calls be resolved on host

--- a/src/provisioners/virtualbox-guest-additions.sh
+++ b/src/provisioners/virtualbox-guest-additions.sh
@@ -12,7 +12,7 @@ $APT_GET install -qq "linux-headers-$(uname -r)" build-essential dkms
 
 ## Fetch latest version
 BASE_URL="https://download.virtualbox.org/virtualbox"
-VERSION="$(wget -q -O- "${BASE_URL}/LATEST.TXT")"
+VERSION="$(wget -q -O- "${BASE_URL}/LATEST-STABLE.TXT")"
 
 ## Install
 ADDITIONS_ISO="VBoxGuestAdditions_${VERSION}.iso"


### PR DESCRIPTION
The latest version, currently 6.1.4 of the VirtualBox Guest Additions breaks the clipboard sync.
Reverting to a stable version makes this works again, despite we might lack some new features added
in it. If newer versions of VirtualBox Guest Additions solves this problem, we will probably upgrade
back.

BREAKING CHANGE: The `modifyvm --clipboard-mode` introduced in VirtualBox 6.1 does not work with the
Guest Additions version 6.0 (the currently stable one). However, VirtualBox 6.1.4 restored the
compatibility with the old `--clipboard` option so make sure to update your VirtualBox.

fix #22