### PR TITLE
feat(desktop): revert to the default ubuntu wallpaper

### DIFF
--- a/src/provisioners/customization.sh
+++ b/src/provisioners/customization.sh
@@ -8,10 +8,9 @@ make install
 popd
 popd
 
-mkdir -p "$HOME/Pictures/Wallpapers/"
-wget -q https://w.wallhaven.cc/full/ox/wallhaven-ox19m9.jpg -O "$HOME/Pictures/Wallpapers/wallhaven-ox19m9.jpg"
-gsettings set org.gnome.desktop.background picture-uri "file://$HOME/Pictures/Wallpapers/wallhaven-ox19m9.jpg"
-gsettings set org.gnome.desktop.screensaver picture-uri "file://$HOME/Pictures/Wallpapers/wallhaven-ox19m9.jpg"
+ubuntu_wallpaper='file:///usr/share/backgrounds/warty-final-ubuntu.png'
+gsettings set org.gnome.desktop.background picture-uri $ubuntu_wallpaper
+gsettings set org.gnome.desktop.screensaver picture-uri $ubuntu_wallpaper
 
 sudo add-apt-repository -y ppa:daniruiz/flat-remix
 sudo apt-get update


### PR DESCRIPTION
The previous one wasn't neutral. The wallpaper should be neutral in order to prevent people to
dislike.

References #26