### PR TITLE
ci: lint the Vagrantfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # File created using '.gitignore Generator' for Visual Studio Code: https://bit.ly/vscode-gig
 
-# Created by https://www.gitignore.io/api/visualstudiocode,linux,node,vagrant,windows
-# Edit at https://www.gitignore.io/?templates=visualstudiocode,linux,node,vagrant,windows
+# Created by https://www.toptal.com/developers/gitignore/api/windows,visualstudiocode,vagrant,node,linux
+# Edit at https://www.toptal.com/developers/gitignore?templates=windows,visualstudiocode,vagrant,node,linux
 
 ### Linux ###
 *~
@@ -74,6 +74,12 @@ typings/
 # Optional eslint cache
 .eslintcache
 
+# Microbundle cache
+.rpt2_cache/
+.rts2_cache_cjs/
+.rts2_cache_es/
+.rts2_cache_umd/
+
 # Optional REPL history
 .node_repl_history
 
@@ -86,27 +92,24 @@ typings/
 # dotenv environment variables file
 .env
 .env.test
+.env*.local
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache
+.parcel-cache
 
-# next.js build output
+# Next.js build output
 .next
 
-# nuxt.js build output
+# Nuxt.js build / generate output
 .nuxt
+dist
 
-# rollup.js default build output
-dist/
-
-# Uncomment the public line if your project uses Gatsby
+# Gatsby files
+.cache/
+# Comment in the public line in if your project uses Gatsby and not Next.js
 # https://nextjs.org/blog/next-9-1#public-directory-support
-# https://create-react-app.dev/docs/using-the-public-folder/#docsNav
 # public
-
-# Storybook build outputs
-.out
-.storybook-out
 
 # vuepress build output
 .vuepress/dist
@@ -120,13 +123,15 @@ dist/
 # DynamoDB Local files
 .dynamodb/
 
-# Temporary folders
-tmp/
-temp/
+# TernJS port file
+.tern-port
+
+# Stores VSCode versions used for testing VSCode extensions
+.vscode-test
 
 ### Vagrant ###
 # General
-.vagrant/*
+.vagrant/
 
 # Log files (if you are creating logs in debug mode, uncomment this)
 # *.log
@@ -136,14 +141,14 @@ temp/
 
 ### VisualStudioCode ###
 .vscode/*
-!.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
-!.vscode/extensions.json
+*.code-workspace
 
 ### VisualStudioCode Patch ###
 # Ignore all local history of files
 .history
+.ionide
 
 ### Windows ###
 # Windows thumbnail cache files
@@ -171,7 +176,7 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
-# End of https://www.gitignore.io/api/visualstudiocode,linux,node,vagrant,windows
+# End of https://www.toptal.com/developers/gitignore/api/windows,visualstudiocode,vagrant,node,linux
 
 # Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,19 @@ dist: bionic
 services:
   - xvfb
 before_install:
-  - curl -fsSLo- https://raw.githubusercontent.com/felipecassiors/scripts/master/linux/install_virtualbox_deb.sh | bash
-  - curl -fsSLo- https://raw.githubusercontent.com/felipecassiors/scripts/master/install_vagrant.sh | bash
+  - bash -c "$(curl -fsSL https://raw.githubusercontent.com/felipecassiors/scripts/master/linux/install_virtualbox_deb.sh)"
+  - bash -c "$(curl -fsSL https://raw.githubusercontent.com/felipecassiors/scripts/master/install_vagrant.sh)"
 script:
   - set -e
+  - ci/lint.sh
   - vagrant up
-  - vagrant package --vagrantfile src/Vagrantfile
+
 before_deploy:
+  - vagrant package --vagrantfile src/Vagrantfile
   - vagrant destroy -f # Save some disk space in case we need in the deploy test
-  - nvm install lts/*
+  - nvm install --lts
   - npm install
+
 deploy:
   - provider: script
     skip_cleanup: true

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Validating Vagrantfile..."
+vagrant validate
+echo
+
+echo "Validating src/Vagrantfile..."
+cd src
+
+# Workaround for validating Vagrantfiles without config.vm.box.
+# See https://github.com/hashicorp/vagrant/issues/12125
+if ! output="$(vagrant validate 2>&1)"; then
+	exit_code=$?
+
+	expected_output="$(
+		cat <<-'EOF'
+			There are errors in the configuration of this machine. Please fix
+			the following errors and try again:
+
+			vm:
+			* A box must be specified.
+		EOF
+	)"
+
+	# Compare disregarding CR line endings characters so it works on Windows
+	if [[ "${output//$'\r'/}" == "${expected_output//$'\r'/}" ]]; then
+		echo "src/Vagrantfile validated successfully."
+	else
+		echo "$output"
+		exit $exit_code
+	fi
+fi
+cd - >/dev/null


### PR DESCRIPTION
So we don't have to run `vagrant package` to check the syntax of the Vagrantfile which comes packaged in the box. This saves some time in the build.

References https://github.com/hashicorp/vagrant/issues/12125.
Closes #21